### PR TITLE
Investigate non-sequential match IDs

### DIFF
--- a/DIAGNOSE_match_counter_updates.py
+++ b/DIAGNOSE_match_counter_updates.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Diagnose script to verify the match counter updates in excel_transaction_matcher.py"""
+
+import re
+
+def check_counter_updates():
+    """Check that all counter updates use the max() logic correctly."""
+    
+    with open('excel_transaction_matcher.py', 'r') as f:
+        content = f.read()
+    
+    # Find all counter update patterns
+    old_pattern = r'shared_match_counter = max\(int\(match\[\'match_id\'\]\[1:\]\) for match in \w+_matches\)'
+    new_pattern = r'shared_match_counter = max\(shared_match_counter, max_\w+_counter\)'
+    
+    old_matches = list(re.finditer(old_pattern, content))
+    new_matches = list(re.finditer(new_pattern, content))
+    
+    print("=== CHECKING MATCH COUNTER UPDATES ===\n")
+    
+    if old_matches:
+        print(f"❌ Found {len(old_matches)} instances of OLD logic (direct assignment):")
+        for match in old_matches:
+            line_num = content[:match.start()].count('\n') + 1
+            print(f"  Line {line_num}: {match.group()}")
+    else:
+        print("✅ No instances of OLD logic found (good!)")
+    
+    print(f"\n✅ Found {len(new_matches)} instances of NEW logic (max preservation):")
+    for match in new_matches:
+        line_num = content[:match.start()].count('\n') + 1
+        print(f"  Line {line_num}: {match.group()}")
+    
+    # Check for each match type
+    match_types = ['LC', 'PO', 'Interunit', 'USD']
+    print("\n=== CHECKING EACH MATCH TYPE ===")
+    
+    for match_type in match_types:
+        # Find the section for this match type
+        if match_type == 'Interunit':
+            section_pattern = rf'# Find interunit loan matches.*?print\(f"\\nInterunit Loan Matching Results:'
+        else:
+            section_pattern = rf'# Find {match_type} matches.*?print\(f"\\n{match_type} Matching Results:'
+        
+        section_match = re.search(section_pattern, content, re.DOTALL)
+        if section_match:
+            section = section_match.group()
+            
+            # Check if it has the counter update
+            if f'max_{match_type.lower()}_counter' in section or f'max_interunit_counter' in section:
+                print(f"✅ {match_type}: Counter update found with max() logic")
+            else:
+                print(f"❌ {match_type}: Missing counter update!")
+        else:
+            print(f"⚠️  {match_type}: Could not find section")
+
+if __name__ == "__main__":
+    check_counter_updates()

--- a/TEST_match_id_logic.py
+++ b/TEST_match_id_logic.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Test to verify the Match ID sequential logic fix without pandas."""
+
+def test_old_logic():
+    """Demonstrate the problem with the old logic."""
+    print("=== OLD LOGIC (BROKEN) ===")
+    
+    shared_match_counter = 0
+    
+    # Simulate LC matching
+    lc_matches = [{'match_id': 'M001'}, {'match_id': 'M002'}, {'match_id': 'M003'}]
+    if lc_matches:
+        # OLD LOGIC: Replaces the counter
+        shared_match_counter = max(int(match['match_id'][1:]) for match in lc_matches)
+    print(f"After LC matches: shared_match_counter = {shared_match_counter}")
+    
+    # Simulate PO matching (only 1 match)
+    po_matches = [{'match_id': 'M001'}]  # This could happen if PO reuses existing match
+    if po_matches:
+        # OLD LOGIC: Replaces the counter - GOES BACKWARDS!
+        shared_match_counter = max(int(match['match_id'][1:]) for match in po_matches)
+    print(f"After PO matches: shared_match_counter = {shared_match_counter}")
+    print("❌ Counter went backwards from 3 to 1!")
+    
+    # Next match would be M002, which already exists!
+    print(f"Next match would be: M{shared_match_counter + 1:03d} (DUPLICATE!)")
+
+def test_new_logic():
+    """Demonstrate the fix with the new logic."""
+    print("\n=== NEW LOGIC (FIXED) ===")
+    
+    shared_match_counter = 0
+    
+    # Simulate LC matching
+    lc_matches = [{'match_id': 'M001'}, {'match_id': 'M002'}, {'match_id': 'M003'}]
+    if lc_matches:
+        # NEW LOGIC: Takes maximum of current counter and highest match
+        max_lc_counter = max(int(match['match_id'][1:]) for match in lc_matches)
+        shared_match_counter = max(shared_match_counter, max_lc_counter)
+    print(f"After LC matches: shared_match_counter = {shared_match_counter}")
+    
+    # Simulate PO matching (only 1 match)
+    po_matches = [{'match_id': 'M001'}]  # This could happen if PO reuses existing match
+    if po_matches:
+        # NEW LOGIC: Preserves the higher counter value
+        max_po_counter = max(int(match['match_id'][1:]) for match in po_matches)
+        shared_match_counter = max(shared_match_counter, max_po_counter)
+    print(f"After PO matches: shared_match_counter = {shared_match_counter}")
+    print("✅ Counter stayed at 3!")
+    
+    # Next match would be M004
+    print(f"Next match would be: M{shared_match_counter + 1:03d} (CORRECT!)")
+
+def test_sequential_generation():
+    """Test full sequential generation across match types."""
+    print("\n=== FULL SEQUENTIAL TEST ===")
+    
+    shared_match_counter = 0
+    shared_existing_matches = {}
+    all_match_ids = []
+    
+    # Simulate different match types
+    match_types = [
+        ("LC", 3),    # 3 LC matches
+        ("PO", 2),    # 2 PO matches
+        ("Interunit", 1),  # 1 Interunit match
+        ("USD", 2),   # 2 USD matches
+    ]
+    
+    for match_type, count in match_types:
+        print(f"\nProcessing {match_type} matches ({count} matches)...")
+        matches = []
+        
+        for i in range(count):
+            # Simulate match key
+            match_key = (f"{match_type}_{i}", 1000 * (i + 1))
+            
+            if match_key in shared_existing_matches:
+                match_id = shared_existing_matches[match_key]
+                print(f"  Reusing existing Match ID: {match_id}")
+            else:
+                shared_match_counter += 1
+                match_id = f"M{shared_match_counter:03d}"
+                shared_existing_matches[match_key] = match_id
+                print(f"  Creating new Match ID: {match_id}")
+            
+            matches.append({'match_id': match_id})
+            all_match_ids.append(match_id)
+        
+        # Update counter using NEW LOGIC
+        if matches:
+            max_counter = max(int(match['match_id'][1:]) for match in matches)
+            shared_match_counter = max(shared_match_counter, max_counter)
+            print(f"  Updated shared_match_counter = {shared_match_counter}")
+    
+    print("\n=== FINAL RESULTS ===")
+    print(f"All Match IDs generated: {all_match_ids}")
+    print(f"✅ All Match IDs are sequential from M001 to M{shared_match_counter:03d}!")
+
+if __name__ == "__main__":
+    test_old_logic()
+    test_new_logic()
+    test_sequential_generation()

--- a/TEST_sequential_match_ids.py
+++ b/TEST_sequential_match_ids.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Test script to verify sequential Match IDs."""
+
+import pandas as pd
+import re
+import os
+
+def check_sequential_match_ids(file_path):
+    """Check if Match IDs in the output file are sequential."""
+    print(f"\nChecking Match IDs in: {file_path}")
+    
+    # Read the Excel file (skip metadata rows)
+    df = pd.read_excel(file_path, header=8)
+    
+    # Get all unique Match IDs (excluding None/NaN)
+    match_ids = df.iloc[:, 0].dropna().unique()
+    
+    if len(match_ids) == 0:
+        print("No Match IDs found in the file.")
+        return True
+    
+    # Extract the numeric part of Match IDs
+    match_numbers = []
+    for match_id in match_ids:
+        if isinstance(match_id, str) and match_id.startswith('M'):
+            try:
+                num = int(match_id[1:])
+                match_numbers.append((num, match_id))
+            except ValueError:
+                print(f"Warning: Invalid Match ID format: {match_id}")
+    
+    # Sort by numeric value
+    match_numbers.sort(key=lambda x: x[0])
+    
+    # Check for sequential order
+    is_sequential = True
+    expected = 1
+    
+    print(f"\nFound {len(match_numbers)} unique Match IDs:")
+    for num, match_id in match_numbers:
+        print(f"  {match_id} (numeric: {num})")
+        if num != expected:
+            print(f"    ❌ Expected M{expected:03d}, but got {match_id}")
+            is_sequential = False
+        expected = num + 1
+    
+    if is_sequential:
+        print("\n✅ Match IDs are sequential!")
+    else:
+        print("\n❌ Match IDs are NOT sequential!")
+    
+    # Show Match Type distribution
+    if 'Match Type' in df.columns or df.shape[1] > 12:  # Last column should be Match Type
+        match_types = df.iloc[:, -1].dropna()
+        if len(match_types) > 0:
+            print("\nMatch Type distribution:")
+            for match_type, count in match_types.value_counts().items():
+                print(f"  {match_type}: {count} rows")
+    
+    return is_sequential
+
+def main():
+    """Main function to check all output files."""
+    output_folder = "Output"
+    
+    # Find all matched Excel files in the output folder
+    matched_files = []
+    if os.path.exists(output_folder):
+        for file in os.listdir(output_folder):
+            if file.endswith("_MATCHED.xlsx"):
+                matched_files.append(os.path.join(output_folder, file))
+    
+    if not matched_files:
+        print(f"No matched files found in {output_folder}")
+        return
+    
+    print(f"Found {len(matched_files)} matched files to check:")
+    
+    all_sequential = True
+    for file_path in matched_files:
+        if not check_sequential_match_ids(file_path):
+            all_sequential = False
+    
+    print("\n" + "="*60)
+    if all_sequential:
+        print("✅ ALL FILES HAVE SEQUENTIAL MATCH IDs!")
+    else:
+        print("❌ SOME FILES HAVE NON-SEQUENTIAL MATCH IDs!")
+    print("="*60)
+
+if __name__ == "__main__":
+    main()

--- a/TEST_visual_demo.py
+++ b/TEST_visual_demo.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Visual demonstration of the Match ID sequencing fix."""
+
+def print_box(title, content):
+    """Print content in a nice box."""
+    width = max(len(title), max(len(line) for line in content)) + 4
+    print("┌" + "─" * width + "┐")
+    print(f"│ {title.center(width-2)} │")
+    print("├" + "─" * width + "┤")
+    for line in content:
+        print(f"│ {line.ljust(width-2)} │")
+    print("└" + "─" * width + "┘")
+
+print("\n🔍 MATCH ID SEQUENCING ISSUE - BEFORE AND AFTER FIX\n")
+
+# Scenario 1: Before Fix
+print("❌ BEFORE FIX - Non-Sequential Match IDs:")
+print_box("Step 1: LC Matching", [
+    "Found 3 LC matches",
+    "Generated: M001, M002, M003",
+    "shared_match_counter = 3  ← Set to max ID"
+])
+print("          ↓")
+print_box("Step 2: PO Matching", [
+    "Found 1 PO match (reused M001)",
+    "Max ID in PO matches: M001",
+    "shared_match_counter = 1  ← OVERWRITES to 1!"
+])
+print("          ↓")
+print_box("Step 3: Interunit Matching", [
+    "Starting from counter = 1",
+    "New match generates: M002  ← DUPLICATE!",
+    "ERROR: M002 already exists from LC!"
+])
+
+print("\n" + "="*60 + "\n")
+
+# Scenario 2: After Fix
+print("✅ AFTER FIX - Sequential Match IDs:")
+print_box("Step 1: LC Matching", [
+    "Found 3 LC matches",
+    "Generated: M001, M002, M003",
+    "shared_match_counter = max(0, 3) = 3"
+])
+print("          ↓")
+print_box("Step 2: PO Matching", [
+    "Found 1 PO match (reused M001)",
+    "Max ID in PO matches: M001 (numeric: 1)",
+    "shared_match_counter = max(3, 1) = 3  ← PRESERVES 3!"
+])
+print("          ↓")
+print_box("Step 3: Interunit Matching", [
+    "Starting from counter = 3",
+    "New match generates: M004  ← SEQUENTIAL!",
+    "shared_match_counter = max(3, 4) = 4"
+])
+print("          ↓")
+print_box("Step 4: USD Matching", [
+    "Starting from counter = 4",
+    "New matches generate: M005, M006",
+    "shared_match_counter = max(4, 6) = 6"
+])
+
+print("\n📊 SUMMARY:")
+print_box("Result", [
+    "✅ All Match IDs are sequential",
+    "✅ No duplicates possible",
+    "✅ Counter never goes backwards",
+    "✅ M001, M002, M003, M004, M005, M006..."
+])
+
+print("\n🔧 THE FIX:")
+print("OLD: shared_match_counter = max(int(match['match_id'][1:]) for match in matches)")
+print("NEW: shared_match_counter = max(shared_match_counter, max_counter)")
+print("\nThe key difference: NEW logic preserves the higher value!")
+print("="*60)

--- a/excel_transaction_matcher.py
+++ b/excel_transaction_matcher.py
@@ -561,7 +561,10 @@ class   ExcelTransactionMatcher:
         
         # Update the shared counter after LC matching
         if lc_matches:
-            shared_match_counter = max(int(match['match_id'][1:]) for match in lc_matches)
+            # Get the highest match counter from all LC matches
+            max_lc_counter = max(int(match['match_id'][1:]) for match in lc_matches)
+            # Update shared counter to ensure next matches start after this
+            shared_match_counter = max(shared_match_counter, max_lc_counter)
         
         print(f"\nLC Matching Results: {len(lc_matches)} matches found")
         
@@ -602,7 +605,10 @@ class   ExcelTransactionMatcher:
         
         # Update the shared counter after PO matching
         if po_matches:
-            shared_match_counter = max(int(match['match_id'][1:]) for match in po_matches)
+            # Get the highest match counter from all PO matches
+            max_po_counter = max(int(match['match_id'][1:]) for match in po_matches)
+            # Update shared counter to ensure next matches start after this
+            shared_match_counter = max(shared_match_counter, max_po_counter)
         
         print(f"\nPO Matching Results: {len(po_matches)} matches found")
         
@@ -640,6 +646,13 @@ class   ExcelTransactionMatcher:
             transactions1, transactions2, interunit_accounts1_unmatched, interunit_accounts2_unmatched,
             self.file1_path, self.file2_path, shared_existing_matches, shared_match_counter
         )
+        
+        # Update the shared counter after Interunit matching
+        if interunit_matches:
+            # Get the highest match counter from all Interunit matches
+            max_interunit_counter = max(int(match['match_id'][1:]) for match in interunit_matches)
+            # Update shared counter to ensure next matches start after this
+            shared_match_counter = max(shared_match_counter, max_interunit_counter)
         
         print(f"\nInterunit Loan Matching Results: {len(interunit_matches)} matches found")
         
@@ -680,7 +693,10 @@ class   ExcelTransactionMatcher:
         
         # Update the shared counter after USD matching
         if usd_matches:
-            shared_match_counter = max(int(match['match_id'][1:]) for match in usd_matches)
+            # Get the highest match counter from all USD matches
+            max_usd_counter = max(int(match['match_id'][1:]) for match in usd_matches)
+            # Update shared counter to ensure next matches start after this
+            shared_match_counter = max(shared_match_counter, max_usd_counter)
         
         print(f"\nUSD Matching Results: {len(usd_matches)} matches found")
         


### PR DESCRIPTION
Update `shared_match_counter` logic to ensure sequential Match IDs across all matching steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e9eabf0-55cf-4070-bf8f-3b9bf476f6ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e9eabf0-55cf-4070-bf8f-3b9bf476f6ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

